### PR TITLE
Use automatic defaults for BB_NUMBER_THREADS and PARALLEL_MAKE

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -160,9 +160,6 @@ LICENSE_FLAGS_WHITELIST = "commercial"
 DL_DIR ?= '/opt/freescale/yocto/imx/'
 SSTATE_DIR ?= '/opt/freescale/yocto/sstate-cache'
 
-BB_NUMBER_THREADS = '4'
-PARALLEL_MAKE = '-j 4'
-
 EOF
     # Change settings according environment
     sed -e "s,MACHINE ??=.*,MACHINE ??= '$MACHINE',g" \


### PR DESCRIPTION
Since poky commit ecb9813 there is automatic detection of the number of cores
so it's better to use that mechanism instead of forcing 4 as default, which
might not be appropriate for machines with a lot of cores.

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>