### PR TITLE
Restore meta-boot2q as it's needed by chromium.

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -25,4 +25,6 @@ BBLAYERS = " \
   ${BSPDIR}/sources/meta-qt5 \
   \
   ${BSPDIR}/sources/meta-boundary \
+  \
+  ${BSPDIR}/sources/meta-boot2qt/meta-boot2qt \
 "


### PR DESCRIPTION
Test: Follow BoundaryDevices tutorial and build "boundary-image-multimedia-full"